### PR TITLE
Added details of FailedToSendToKitchen webhook (Orders section)

### DIFF
--- a/spec/definitions/order-preparation/webhooks/failed-to-send-to-kitchen.yaml
+++ b/spec/definitions/order-preparation/webhooks/failed-to-send-to-kitchen.yaml
@@ -1,0 +1,4 @@
+type: object
+properties:
+  OrderId: 
+    type: string

--- a/spec/paths/orders/webhooks/failed-to-send-to-kitchen.yaml
+++ b/spec/paths/orders/webhooks/failed-to-send-to-kitchen.yaml
@@ -1,0 +1,14 @@
+post:
+  tags:
+  - order-webhooks
+  summary: Failed to send to kitchen
+  description: "This webhook will be invoked if we experience an error or timeout in sending an order to the underlying POS / kitchen screen. When notified via this webhook, typically you will perfom some form of alerting or backup flow (e.g. ask the operator to enter the order manually into the POS). NOTE: This message contains the `OrderId`, but not the full order. It is assumed that you have stored/cached the full order details earlier in the flow - e.g. via the [/order-is-ready-for-preparation](#/paths/~1order-is-ready-for-preparation/post) webhook."
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          "$ref": "#/definitions/failed-to-send-to-kitchen"
+  responses:
+    '200':
+      description: Respond with a 200 status code to indicate that you have received the notification.


### PR DESCRIPTION
The documentation for the `FailedToSendToKitchen` webhook was missing for the Skip integration. It is useful to have it here for them and future partner integrations.